### PR TITLE
format-f: add new tests for corner case, where neither w nor d are set

### DIFF
--- a/format-f.lsp
+++ b/format-f.lsp
@@ -552,3 +552,7 @@
 ;; Most implementations print .00
 (def-format-test format.f.47
     "~3f" (0.000001) "0.0")
+
+;; CCL 1.10 and ECL 15.3.7 ignore k parameter when w and d aren't set
+(def-format-test format.f.48
+    "~,,2f" (0.1) "10.0")


### PR DESCRIPTION
Both CCL and ECL ignore k parameter, when w and d aren't set, for
instance:

(format t "~,,2F" 0.1) ; -> should return 10.0, but returns 0.1

Signed-off-by: Daniel Kochmański daniel@turtleware.eu
